### PR TITLE
Generates local SQLite DB and caches data in it

### DIFF
--- a/lib/rails_bulk_writer/lib/delete_marker.rb
+++ b/lib/rails_bulk_writer/lib/delete_marker.rb
@@ -6,12 +6,5 @@ module RailsBulkWriter
         resets { to_delete = {} }
     end
 
-    class CacheConfig < ActiveSupport::CurrentAttributes
-        # using CurrentAttributes to keep it specific to sequential requests
-        # With current Rails, this is equivalent to a sub-hash within the Thread.current
 
-        attribute :cache_db_name
-
-        resets {} # do not erase this data upon reset
-    end
 end


### PR DESCRIPTION
This 
1. Generates a local SQLite DB
2. Configures that DB to match the schema of the primary DB (running db:prepare on it) if migrations are arranged properly
3. resets the deletion-ids between request / job-cycles